### PR TITLE
Fix an unit test failing on Ubuntu only (#16).

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -342,7 +342,7 @@
     <build>
         <plugins>
             <!-- Run Liquibase scripts on the integration database *BEFORE* generating Querydsl table classes from database schema -->
-            <!-- Liquibase scripts can also be manually run by "mvn liquibase:updateTestingRollback" / "mvn liquibase:rollback" + a profile
+            <!-- Liquibase scripts can also be manually run by "mvn liquibase:updateTestingRollback" / "mvn liquibase:rollback" + a profile -->
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
@@ -365,7 +365,6 @@
                     </execution>
                 </executions>
             </plugin>
--->
             <!-- Generate Querydsl table classes from the integration database schema -->
             <plugin>
                 <groupId>com.querydsl</groupId>

--- a/server/src/test/java/com/decathlon/ara/report/asset/FileAssetServiceTest.java
+++ b/server/src/test/java/com/decathlon/ara/report/asset/FileAssetServiceTest.java
@@ -56,7 +56,7 @@ public class FileAssetServiceTest {
     @Test
     public void saveScreenshot_should_not_fail_but_return_null_on_write_failure() {
         // GIVEN
-        when(araConfiguration.getFileHomeFolder()).thenReturn("/var/proc/?/not-writable"); // ... on Unix nor on Windows
+        when(araConfiguration.getFileHomeFolder()).thenReturn("/bin/mkdir/?/not-writable"); // ... on Unix nor on Windows
 
         // WHEN
         final String url = cut.saveScreenshot(new byte[] { 'a', 'n', 'y' }, "any");
@@ -94,7 +94,7 @@ public class FileAssetServiceTest {
     @Test
     public void saveHttpLogs_should_not_fail_but_return_null_on_write_failure() {
         // GIVEN
-        when(araConfiguration.getFileHomeFolder()).thenReturn("/var/proc/?/not-writable"); // ... on Unix nor on Windows
+        when(araConfiguration.getFileHomeFolder()).thenReturn("/bin/mkdir/?/not-writable"); // ... on Unix nor on Windows
         when(araConfiguration.getFileHttpLogsSubFolder()).thenReturn("/directory");
 
         // WHEN


### PR DESCRIPTION
Fix an issue where the build fails on Ubunutu due to 2 unit tests
failing. They fail because we try to create a directory on a reserved
location, but this will not failed (and create unwanted behaviors on the
OS) when runned in sudo.
Fix this by replacing the path from a reserved location to a binary
location.

Issue #16 