### PR TITLE
Use absolute path while creating the docker database (#15)

### DIFF
--- a/db/manage-db.sh
+++ b/db/manage-db.sh
@@ -66,7 +66,11 @@ function startContainer {
 }
 
 function createContainer {
-	dataDir="$1"
+	if [[ "$1" == '/'* ]]; then
+	    dataDir="$1"
+	elif [[ "$1" == '.'* ]]; then
+	    dataDir="`pwd`/$1"
+	fi
 	echo "[ARA] Create the folder on host if not exists..."
 	run "mkdir -p $dataDir"
 	echo "[ARA] Pulling base mysql image..."
@@ -75,7 +79,7 @@ function createContainer {
 	docker_cmd="docker run"
 	docker_cmd="$docker_cmd --name $CONTAINER_NAME"
 	docker_cmd="$docker_cmd -e MYSQL_ROOT_PASSWORD=$PASSWORD"
-	docker_cmd="$docker_cmd -v /$dataDir:/var/lib/mysql" # Starting-slashes are for Windows compatibility
+	docker_cmd="$docker_cmd -v $dataDir:/var/lib/mysql" # Starting-slashes are for Windows compatibility
 	docker_cmd="$docker_cmd -v /$CONF_DIR:/etc/mysql/conf.d"
 	docker_cmd="$docker_cmd -v /$SQL_DIR:/docker-entrypoint-initdb.d"
 	docker_cmd="$docker_cmd -p $PORT:3306"

--- a/db/manage-db.sh
+++ b/db/manage-db.sh
@@ -66,10 +66,10 @@ function startContainer {
 }
 
 function createContainer {
-	if [[ "$1" == '/'* ]]; then
-	    dataDir="$1"
-	elif [[ "$1" == '.'* ]]; then
+	if [[ "$1" == '.'* ]]; then
 	    dataDir="`pwd`/$1"
+	else
+	    dataDir="$1"
 	fi
 	echo "[ARA] Create the folder on host if not exists..."
 	run "mkdir -p $dataDir"


### PR DESCRIPTION
While using the git-bash for windows environment with the manage-db
script, the docker run may create a false location for the container's
volume.
Fix this by checking if the path given in parameter of 'create' is
absolute or not, and if not prefix it with '$PWD/'.

Fix Issue #15 