### PR TITLE
Upgrade webpack-bundle-analyzer to version 3.3.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -87,7 +87,7 @@
     "vue-style-loader": "^4.1.2",
     "vue-template-compiler": "2.5.17",
     "webpack": "^2.6.1",
-    "webpack-bundle-analyzer": "^2.13.1",
+    "webpack-bundle-analyzer": "3.3.2",
     "webpack-dev-middleware": "^1.10.0",
     "webpack-hot-middleware": "^2.24.3",
     "webpack-merge": "^4.1.4"


### PR DESCRIPTION
Fix the security alert on webpack-bundle-analyzer

```
moderate severity
Vulnerable versions: < 3.3.2
Patched version: 3.3.2
Versions of webpack-bundle-analyzer prior to 3.3.2 are vulnerable to Cross-Site Scripting. The package uses JSON.stringify() without properly escaping input which may lead to Cross-Site Scripting.
```