### PR TITLE
fix: Remove all the occurences of the dev db's password

### DIFF
--- a/database/instance/manage-db.sh
+++ b/database/instance/manage-db.sh
@@ -26,7 +26,7 @@ LOGS=1
 # The name of the container which will holds the db to manipulate
 CONTAINER_NAME=ara-db
 # The password of the Database (you should use a secret here instead).
-PASSWORD=V*n6MxBq7mr?4P?M
+PASSWORD=dev_password_to_change
 # The container port exposed to the host.
 PORT=3306
 

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -141,7 +141,6 @@
                     jdbc:mysql://localhost:3306/ara-dev?useUnicode=yes&amp;characterEncoding=UTF-8
                 </liquibase.database.url>
                 <liquibase.database.username>root</liquibase.database.username>
-                <liquibase.database.password>V*n6MxBq7mr?4P?M</liquibase.database.password>
                 <skipPitest>true</skipPitest>
                 <skip.integration.tests>true</skip.integration.tests>
             </properties>

--- a/database/src/main/resources/db-application-dev.properties
+++ b/database/src/main/resources/db-application-dev.properties
@@ -19,7 +19,8 @@ spring.profiles.include=dev
 # The ARA-core development database; to run one ARA per application, override this URL with one schema per application
 spring.datasource.url=jdbc:mysql://localhost:3306/ara-dev?useUnicode=yes&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=V*n6MxBq7mr?4P?M
+# You need to set the property -Dspring.datasource.password while launching the application to connect to the database.
+
 ## SQL Logging
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true

--- a/docker/ara-db/Dockerfile
+++ b/docker/ara-db/Dockerfile
@@ -2,7 +2,8 @@ FROM mariadb:5.5.56
 
 ENV MYSQL_DATABASE=ara
 ENV MYSQL_USER=root
-ENV MYSQL_ROOT_PASSWORD=V*n6MxBq7mr?4P?M
+# Note if you build the Docker image directly from this file and not from the manage-db.sh, then you'll need to set the
+# environement Variable MYSQL_ROOT_PASSWORD
 
 ENTRYPOINT [ "docker-entrypoint.sh", \
              "--autocommit=OFF", \

--- a/docker/ara-server/default-config/application.properties
+++ b/docker/ara-server/default-config/application.properties
@@ -17,7 +17,7 @@
 
 spring.datasource.url=jdbc:mysql://host.docker.internal:3306/ara?useUnicode=yes&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=V*n6MxBq7mr?4P?M
+# You need to set the property -Dspring.datasource.password while launching the application to connect to the database.
 
 spring.resources.static-locations=classpath:/dist,classpath:/META-INF/resources,file:///opt/ara/data/assets
 

--- a/server/README.adoc
+++ b/server/README.adoc
@@ -137,75 +137,43 @@ Run the setup once, so Liquibase has a chance to create all tables.
 
 == Setup Development Machine
 
-=== Install MariaDB
-Download MariaDB here, version 5.5.56 (same version than on server): +
-https://downloads.mariadb.org/mariadb/5.5.56/
+=== Install the Database
 
-Follow this tutorial: +
-https://mariadb.com/kb/fr/installing-mariadb-msi-packages-on-windows/ +
-For the root password, use V*n6MxBq7mr?4P?M +
-Check “Use UTF-8 as default server’s character set” +
-Keep other default choice (server port 3306, optimize for transactions, etc.)
+To install the Database for your developments, you'll need Docker and a
+shell environement (available by default on macOS & GNU/Linux, and by
+using Git for Windows or WSL on Windows).
 
-Go to “C:\Program Files\MariaDB 5.5\data” +
-Open my.ini as an Administrator, and paste this content:
+Once thoses prerequisites are satisfied, do the following in a shell
+terminal from the root folder of ARA (called `ARA_ROOT` bellow) :
+```
+> cd database/instance
+> ./manage-db.sh create <PATH_WHERE_TO_PERSIST_DATAS_ON_DISK>
+```
 
-    [mysqld]
-    datadir=C:/Program Files/MariaDB 5.5/data
-    port=3306
-    sql_mode="STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"
-    default_storage_engine=innodb
-    innodb_buffer_pool_size=2033M
-    innodb_log_file_size=50M
-    character-set-server=utf8
-    innodb_large_prefix
-    innodb_file_format=BARRACUDA
-    innodb_file_per_table
-    innodb_file_format_max=BARRACUDA
-    autocommit=OFF
-    [client]
-    port=3306
+Once this script is done, wait 1 minute and do a `docker ps`. You should
+see the container `ara-db` up and running on port 3306.
 
-Press Win+R, execute “services.msc” and restart the “MySQL” service for it to use the new configuration.
+=== Populate the database
 
-=== Create Data Bases
-You can download MySQL Workbench GPL (the equivalent to SQL Developer):
-https://dev.mysql.com/downloads/workbench/
+Once your database is up and running, you can at any moment run the
+following to populate it with the database's structure and some referentials
+informations. You will need Maven and a database up and running, then you
+can do those commands from the root folder of ARA.
 
-Connect via MySql Workbench, and execute:
+```
+> cd database
+> mvn -Pdev liquibase:updateTestingRollback -Dliquibase.database.password=YOUR_DATABASE_PASSWORD
+```
 
-    CREATE DATABASE `ara-dev-in`;
+This command will call all the liquibase scripts and update the database
+structure and datas if needed.
 
-This will be the schema used by integration tests on your local development environment.
-
-Then, for each application you will maintain, create a schema for running the application on your local development machine:
-
-    CREATE DATABASE `ara-{app}-dev`;
-
-Where `{app}` is the id of your application(s).
-
-If you work on ARA Core, you CAN create this schema to test a core ARA (without application-dependant configuration):
-
-    CREATE DATABASE `ara-dev`;
-
-=== Initialize the Development Data Base
-To create the tables, run this command in ara-server directory:
-
-    mvn -Dspring.config.location=classpath:/,classpath:/config/{app}/ liquibase:updateTestingRollback -P{profile}
-
-Where `{app}` is the id of your application and `{profile}` is the profile linked to your app in the `ara-server/pom.xml` file. +
-Repeat for each application you maintain.
-
-Then, to populate some data, you can initiate the Demo project :
+Finally, to populate some data, you can initiate the Demo project :
 
 * Run Ara server and Ara client
 * Go the Dropdown menu in the top left corner
 * Click on Manage Project List
 * At the center of the screen, click on the button "Create the Demo project"
-
-If you work on ARA Core, you CAN initiate this schema to test a core ARA (without application-dependant configuration):
-
-    mvn liquibase:updateTestingRollback -Pdev
 
 === Install Lombok in Your IDE
 

--- a/server/src/main/resources/application-dev_in.properties
+++ b/server/src/main/resources/application-dev_in.properties
@@ -21,6 +21,6 @@ spring.profiles.include=dev_common
 
 spring.datasource.url=jdbc:mysql://localhost:3306/ara-dev-in?useUnicode=yes&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=V*n6MxBq7mr?4P?M
+# You need to set the property -Dspring.datasource.password while launching the application to connect to the database.
 
 ara.clientBaseUrl=http://integration-url/


### PR DESCRIPTION
Fix #82 

Remove all the occurences of the dev database's password from all the files of the project except `manage-db.sh` which is supposed to create the database locally only.