### PR TITLE
fix: Remove useless command 'docker-compose pull' in readme.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,24 +29,22 @@ Please note the following :
 
 1. Open a Powershell Command Prompt
 2. Run the command `Invoke-WebRequest -OutFile docker-compose.yml https://raw.githubusercontent.com/Decathlon/ara/master/docker-compose.yml`
-3. Run the command `docker-compose pull`
-4. Run the command `docker-compose up`
-5. Open up a browser on `http://localhost:8080`
-6. Enjoy !
-7. To stop it, in the command line, just do a `docker-compose down` in the same directory as the `docker-compose.yml`
-8. To restart it, in the command line do a `docker-compose up` in the same directory as the `docker-compose.yml`
+3. Run the command `docker-compose up`
+4. Open up a browser on `http://localhost:8080`
+5. Enjoy !
+6. To stop it, in the command line, just do a `docker-compose down` in the same directory as the `docker-compose.yml`
+7. To restart it, in the command line do a `docker-compose up` in the same directory as the `docker-compose.yml`
 
 
 === I've got a Mac (or a GNU/Linux PC) !
 
 1. Open a Terminal
 2. Run the command `wget https://raw.githubusercontent.com/Decathlon/ara/master/docker-compose.yml`
-3. Run the command `docker-compose pull`
-4. Run the command `docker-compose up`
-5. Open up a browser on `http://localhost:8080`
-6. Enjoy !
-7. To stop it, in the command line, just do a `docker-compose down` in the same directory as the `docker-compose.yml`
-8. To restart it, in the command line do a `docker-compose up` in the same directory as the `docker-compose.yml`
+3. Run the command `docker-compose up`
+4. Open up a browser on `http://localhost:8080`
+5. Enjoy !
+6. To stop it, in the command line, just do a `docker-compose down` in the same directory as the `docker-compose.yml`
+7. To restart it, in the command line do a `docker-compose up` in the same directory as the `docker-compose.yml`
 
 == How to install it on my Infrastructure
 


### PR DESCRIPTION
from sections Windows PC and Mac/Linux PC

Fix #143