### PR TITLE
fix: Restrict the several countries execution to night cycles.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5343,9 +5343,9 @@
       "dev": true
     },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "gzip-size": {
@@ -7902,6 +7902,12 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "growl": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+          "dev": true
+        },
         "has-flag": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -7981,6 +7987,12 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
+        },
+        "growl": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+          "dev": true
         },
         "has-flag": {
           "version": "1.0.0",

--- a/server/src/main/java/com/decathlon/ara/web/rest/FunctionalityResource.java
+++ b/server/src/main/java/com/decathlon/ara/web/rest/FunctionalityResource.java
@@ -100,6 +100,12 @@ public class FunctionalityResource {
         dtoToUpdate.setId(id); // HTTP PUT requires the URL to be the URL of the entity
         try {
             FunctionalityDTO updatedDto = service.update(projectService.toId(projectCode), dtoToUpdate);
+            if (null == updatedDto.getCreated()) {
+                updatedDto.setCreated("");
+            }
+            if (null == updatedDto.getComment()) {
+                updatedDto.setComment("");
+            }
             return ResponseEntity.ok()
                     .headers(HeaderUtil.entityUpdated(NAME, updatedDto.getId()))
                     .body(updatedDto);


### PR DESCRIPTION
## Type of modification

* [ ] Breaking change
* [ ] New Feature
* [x] Bug Fix
* [ ] Chore (refactor, documentation, tests... all the changes with no impact on ARA functionalities.) 

## Changes description

Fix #5 
Update the `Functionalities -> Cartography` screen to refresh the non mandatory text fields when they're updated and removed.

## Technical description

Fill the `comment` and `created` attributes in the `FunctionalityDTO` with empty strings when their values are `null` after the DB update to force them to appear in the response's body.

+ Some minor clean up (useless (un)boxing + check nullity in responses' body in the `FunctionalityResourceIT` test class).

## PR CheckList

Please make sure your PullRequest respect all those items :

* [X] Your PR's title has the prefix : `feat:`, `fix:` or `chore:`
* [X] Unless your PR is related to a Hotfix (and approved by a ARA maintener), the targeted branch for it is the branch `version/X.Y.Z` and **not** `master`
* [X] You have asked a review from one of the ARA maintainer in your PR.
* [X] If your PR is related to an issue, add the issue's number in it.
* [X] All the code you added is documented.
* [X] All the code you added is tested and the  tests are in success.
* [X] You already signed the [Contributor License Agreement](https://github.com/Decathlon/ara/blob/master/contributor-licence-agreement.adoc) and give us the document