### PR TITLE
chore: enable GH security scan

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [version/**, master, task/security-test]
+    branches: [version/**, master]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [version/**, master]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,54 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [version/**, master, task/security-test]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [version/**, master]
+  schedule:
+    - cron: '0 13 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+
+    # If this run was triggered by a pull request event, then checkout
+    # the head of the pull request instead of the merge commit.
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      # Override language selection by uncommenting this and choosing your languages
+      # with:
+      #   languages: go, javascript, csharp, python, cpp, java
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.0.6.RELEASE</version>
+                <version>2.0.9.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Type of modification

* [ ] Breaking change
* [ ] New Feature
* [ ] Bug Fix
* [X] Chore (refactor, documentation, tests... all the changes with no impact on ARA functionalities.) 

## Changes description

Github has a static analysis tool available for open source project. This PR enable the feature. (I use the default configuration)

## Technical description

Add a github action that launch the codeql analyze step. The GH action is the one github gives, I use the default setup.

## PR CheckList

Please make sure your PullRequest respect all those items :

* [X] Your PR's title has the prefix : `feat:`, `fix:` or `chore:`
* [X] Unless your PR is related to a Hotfix (and approved by a ARA maintener), the targeted branch for it is the branch `version/X.Y.Z` and **not** `master`
* [X] You have asked a review from one of the ARA maintainer in your PR.
* [X] If your PR is related to an issue, add the issue's number in it.
* [X] All the code you added is documented.
* [X] All the code you added is tested and the  tests are in success.
* [X] You already signed the [Contributor License Agreement](https://github.com/Decathlon/ara/blob/master/contributor-licence-agreement.adoc) and give us the document