### PR TITLE
fix: continue uploading execution after return

### DIFF
--- a/server/src/main/java/com/decathlon/ara/web/rest/ExecutionResource.java
+++ b/server/src/main/java/com/decathlon/ara/web/rest/ExecutionResource.java
@@ -252,19 +252,22 @@ public class ExecutionResource {
                                        @RequestParam("branch") String branch,
                                        @RequestParam("cycle") String cycle,
                                        @RequestParam("zip") MultipartFile zipFile) {
-        ResponseEntity<Void> result;
+        ResponseEntity<Void> result = ResponseEntity.status(HttpStatus.ACCEPTED).build();
         log.info("Receiving new zip report for project {}...", projectCode);
         try {
             long projectId = projectService.toId(projectCode);
             service.uploadExecutionReport(projectId, projectCode, branch, cycle, zipFile);
-            result = ResponseEntity.ok().build();
         } catch (NotFoundException | IllegalArgumentException e) {
-            log.error("The given project doesn't exists or doesn't use the FS indexer.", e);
+            log.error("Some parameters may not be correct");
+            log.error("Please check your logs, or the stacktrace below:", e);
             result = ResponseUtil.handle(new BadRequestException(e.getMessage(), Entities.EXECUTION, VALIDATION_ERRROR));
         } catch (IOException ex) {
             log.error("Unable to index the uploaded execution.", ex);
             result = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
+
+        log.info("Freeing the /upload resource...");
+        log.info("ARA is still uploading executions");
         return result;
     }
 

--- a/server/src/test/java/com/decathlon/ara/service/ExecutionServiceTest.java
+++ b/server/src/test/java/com/decathlon/ara/service/ExecutionServiceTest.java
@@ -375,14 +375,16 @@ public class ExecutionServiceTest {
         File executionPath = new File("/opt/executions/123");
         PlannedIndexation plannedIndexation = new PlannedIndexation().withCycleDefinition(cycleDefinition).withExecutionFolder(executionPath);
         List<File> unzipMock = Collections.singletonList(executionPath);
+
+        // When
         doReturn(unzipMock).when(cut).unzipExecutions(any(), any(), any());
         doReturn("/opt/data/{{project}}/{{branch}}/{{cycle}}").when(settingService).get(projectId, Settings.EXECUTION_INDEXER_FILE_EXECUTION_BASE_PATH);
         doReturn(Optional.of(cycleDefinition)).when(cycleDefinitionRepository).findByProjectIdAndBranchAndName(projectId, branch, cycle);
         doNothing().when(executionIndexerService).indexExecution(any());
-        // When
-        cut.uploadExecutionReport(projectId, projectCode, branch, cycle, zip);
+
         // Then
-        verify(executionIndexerService).indexExecution(plannedIndexation);
+        cut.uploadExecutionReport(projectId, projectCode, branch, cycle, zip);
+        verify(cut).launchExecutionDirectoriesProcessingThread(anyLong(), anyList(), any(CycleDefinition.class));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
## Type of modification

* [ ] Breaking change
* [ ] New Feature
* [x] Bug Fix
* [ ] Chore (refactor, documentation, tests... all the changes with no impact on ARA functionalities.) 

## Changes description

ARA now uploads executions asynchronously, i.e. it doesn't wait for the upload to finish to return.
**Add some quick description about what your PullRequest change in
ARA's feature/behavior**

## Technical description

**Add a quick description about what your PullRequest change in 
ARA's code. (example: add a processor check in...)**

## PR CheckList

Please make sure your PullRequest respect all those items :

* [ ] Your PR's title has the prefix : `feat:`, `fix:` or `chore:`
* [ ] You have asked a review from one of the ARA maintainer in your PR.
* [ ] If your PR is related to an issue, add the issue's number in it.
* [ ] All the code you added is documented.
* [ ] All the code you added is tested and the  tests are in success.
* [ ] You already signed the [Contributor License Agreement](https://github.com/Decathlon/ara/blob/main/doc/contributing/contributor-licence-agreement.adoc) and give us the document
