### PR TITLE
chore: use profile instead of env var in dev

### DIFF
--- a/code/api/api/src/main/resources/application-dev.yaml
+++ b/code/api/api/src/main/resources/application-dev.yaml
@@ -26,3 +26,7 @@ logging:
         type:
           descriptor:
             sql: INFO
+
+info:
+  app:
+    version: DEV

--- a/code/docker-compose.dev.yaml
+++ b/code/docker-compose.dev.yaml
@@ -10,8 +10,7 @@ services:
     networks:
       ara-dev: {}
     environment:
-      - INFO_APP_VERSION=DEV
-      - ARA_OAUTH2_MODE=oauth2-mock
+      # - ARA_OAUTH2_MODE=oauth2
     command: ['/bin/bash', '-c', 'mvn -Pdev ${OPTIONAL_CLEAN} spring-boot:run -pl api']
   front:
     image: node:12


### PR DESCRIPTION
Use profile instead of env var

## Type of modification

* [ ] Breaking change
* [ ] New Feature
* [ ] Bug Fix
* [x] Chore (refactor, documentation, tests... all the changes with no impact on ARA functionalities.) 

## Changes description

Just a little change to clarify docker compose conf

## Technical description

Use spring profile to store data instead of setting an env var

## PR CheckList

Please make sure your PullRequest respect all those items :

* [ ] Your PR's title has the prefix : `feat:`, `fix:` or `chore:`
* [ ] You have asked a review from one of the ARA maintainer in your PR.
* [ ] If your PR is related to an issue, add the issue's number in it.
* [ ] All the code you added is documented.
* [ ] All the code you added is tested and the  tests are in success.
* [ ] You already signed the [Contributor License Agreement](https://github.com/Decathlon/ara/blob/main/doc/contributing/contributor-licence-agreement.adoc) and give us the document
