### PR TITLE
docs: fix 'datas' typo in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ to explore ARA features !!
 Please note the following :
 
 * You'll need https://docs.docker.com/install/[Docker]
-* All the datas that you import in ARA won't be persisted.
+* All the data that you import in ARA won't be persisted.
 * The port 7000, 9000, 5432 must be available locally.
 * Add to `/etc/hosts` (Linux OS) or to `/private/etc/hosts` (MacOS) or to `c:\Windows\System32\drivers\etc\` (Windows) `127.0.0.1 oauth2.dev.localhost`
 


### PR DESCRIPTION
Small fix: 'All the datas that you import' → 'All the data that you import'.